### PR TITLE
Deprecate Node.js 4 in engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Dmitry Sorin <info@staypositive.ru>",
   "license": "MIT",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
BREAKING CHANGE: This module no longer supports Node.js 4